### PR TITLE
Fix theme.json palette merge error when child theme is activated

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -275,7 +275,7 @@ function design_system_combine_parent_child_theme_json( $theme_json ) {
     }
 
     // Merge the parent palette with the child palette.
-    $merged_palette = array_merge( $parent_palette, $child_palette['theme'] );
+    $merged_palette = array_merge( $parent_palette, $child_palette );
 
     // Prepare the new data with the validated palette.
     $new_data = array(


### PR DESCRIPTION
Remove invalid array access to ['theme'] which doesn't exist in the child theme's theme.json structure. The palette is a flat array, not nested under a 'theme' key. This fixes the 'Undefined index: theme' notice and 'array_merge() expected parameter 2 to be array' warning when activating a child theme.

Fixes [DSWP-965](https://citz-gdx.atlassian.net/browse/DSWP-965)

[DSWP-965]: https://citz-gdx.atlassian.net/browse/DSWP-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ