### PR TITLE
Update secondary-footer.html

### DIFF
--- a/parts/secondary-footer.html
+++ b/parts/secondary-footer.html
@@ -4,9 +4,9 @@
     style="padding-right: 1rem; padding-left: 1rem"
     ><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
     <div class="wp-block-group alignwide"
-        ><!-- wp:template-part {"slug":"secondary-footer-links","theme":"design-system-wordpress-theme"} /-->
+        ><!-- wp:template-part {"slug":"secondary-footer-links"} /-->
 
-        <!-- wp:template-part {"slug":"footer-logo-light","theme":"design-system-wordpress-theme","area":"footer"} /--></div
+        <!-- wp:template-part {"slug":"footer-logo-light","area":"footer"} /--></div
     >
     <!-- /wp:group --></div
 >

--- a/parts/secondary-footer.html
+++ b/parts/secondary-footer.html
@@ -2,6 +2,12 @@
 <div
     class="wp-block-group alignwide has-base-background-color has-background has-background-dark-blue-background-color"
     style="padding-right: 1rem; padding-left: 1rem"
-    ><!-- wp:template-part {"slug":"top-header-row"} /--></div
+    ><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+    <div class="wp-block-group alignwide"
+        ><!-- wp:template-part {"slug":"secondary-footer-links","theme":"design-system-wordpress-theme"} /-->
+
+        <!-- wp:template-part {"slug":"footer-logo-light","theme":"design-system-wordpress-theme","area":"footer"} /--></div
+    >
+    <!-- /wp:group --></div
 >
 <!-- /wp:group -->


### PR DESCRIPTION
This pull request updates the structure of the `parts/secondary-footer.html` file to improve the layout and content organization of the secondary footer. The main change is the introduction of a new flex group that organizes footer links and the footer logo.

**Footer layout improvements:**

* Replaced the old template part with a new flex `wp:group` that uses `justifyContent: space-between` and `flexWrap: wrap` for better alignment and responsiveness.
* Added the `secondary-footer-links` and `footer-logo-light` template parts within the new group, ensuring both footer links and the logo are displayed in the secondary footer.