### PR TITLE
Update bc-gov-logo-supported-light.php

### DIFF
--- a/patterns/archive/bc-gov-logo-supported-light.php
+++ b/patterns/archive/bc-gov-logo-supported-light.php
@@ -8,6 +8,12 @@
  */
 ?>
 
-<!-- wp:image {"width":"175px","height":"auto","sizeSlug":"full","linkDestination":"none","className":"is-style-default"} -->
-<figure class="wp-block-image size-full is-resized is-style-default"><img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/BCID_Supported_H_Solid_rev.png' ); ?>" alt="Supported by the Province of British Columbia" style="width:175px;height:auto"/></figure>
-<!-- /wp:image -->
+<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"},"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-right:0;padding-left:0">
+    <!-- wp:image {"width":"175px","height":"auto","sizeSlug":"full","linkDestination":"none","className":"is-style-default"} -->
+    <figure class="wp-block-image size-full is-resized is-style-default"><img
+            src="<?php echo esc_url(get_template_directory_uri() . '/assets/images/BCID_Supported_H_Solid_rev.png'); ?>"
+            alt="Supported by the Province of British Columbia" style="width:175px;height:auto" /></figure>
+    <!-- /wp:image -->
+</div>
+<!-- /wp:group -->

--- a/patterns/archive/bc-gov-logo-supported-light.php
+++ b/patterns/archive/bc-gov-logo-supported-light.php
@@ -12,7 +12,7 @@
 <div class="wp-block-group" style="padding-right:0;padding-left:0">
     <!-- wp:image {"width":"175px","height":"auto","sizeSlug":"full","linkDestination":"none","className":"is-style-default"} -->
     <figure class="wp-block-image size-full is-resized is-style-default"><img
-            src="<?php echo esc_url(get_template_directory_uri() . '/assets/images/BCID_Supported_H_Solid_rev.png'); ?>"
+            src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/BCID_Supported_H_Solid_rev.png' ); ?>"
             alt="Supported by the Province of British Columbia" style="width:175px;height:auto" /></figure>
     <!-- /wp:image -->
 </div>


### PR DESCRIPTION
This pull request makes a minor update to the `patterns/archive/bc-gov-logo-supported-light.php` file to improve the structure and styling of the BC Gov logo block. The logo image is now wrapped in a WordPress group block with explicit padding and layout settings for better consistency and alignment.

**Block structure and styling improvements:**

* Wrapped the logo image in a `wp:group` block with zero left and right padding and no block gap, enhancing layout control and visual consistency.